### PR TITLE
전역 css가 infowindow styled component를 덮어쓰는 이슈

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-html, body, div, span, applet, object, iframe,
+/* html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
@@ -17,25 +17,26 @@ time, mark, audio, video {
 	font-size: 100%;
 	font: inherit;
 	vertical-align: baseline;
-}
+} */
 
 @font-face {
-  font-family: 'EliceDigitalBaeum-Bd';
-  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_elice@1.0/EliceDigitalBaeum-Bd.woff2') format('woff2');
+  font-family: "EliceDigitalBaeum-Bd";
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_elice@1.0/EliceDigitalBaeum-Bd.woff2")
+    format("woff2");
   font-weight: normal;
   font-style: normal;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif,'EliceDigitalBaeum-Bd';
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif, "EliceDigitalBaeum-Bd";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }


### PR DESCRIPTION
구글 번역도 막아보려고 했는데 안되네요 ㅠ
한국어를 한국어로 번역하면 내용이 이상해지더라구요
이슈로 자세히 남기겠습니다.

const meta = document.createElement("meta");
  meta.name = "google";
  meta.content = "notranslate";
  document.getElementsByTagName("head")[0].appendChild(meta);
  
  
https://nashorn.tistory.com/entry/%ED%81%AC%EB%A1%AC-%EC%9B%B9%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C-%EB%B2%88%EC%97%AD-%ED%8C%9D%EC%97%85-%EB%B9%84%ED%99%9C%EC%84%B1%ED%99%94