### PR TITLE
@cyberjam/drawer UI

### DIFF
--- a/src/components/NaverMap/index.js
+++ b/src/components/NaverMap/index.js
@@ -34,8 +34,8 @@ const NaverMap = forwardRef((props, ref) => {
 
 NaverMap.defaultProps = {
     id: 'map',
-    center: { lat: 37.3595704, lng: 127.105399 },
-    zoom: 10,
+    center: { lat: 37.5666103, lng: 126.9783882 },
+    zoom: 12,
     width: '100vw',
     height: '100vh',
 };

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -4,6 +4,8 @@ import styled, { useTheme } from 'styled-components';
 const Drawer = ({ state, hide, onToggleClick }) => {
     const theme = useTheme();
 
+    const drawerOpenIcon = 'https://i.ibb.co/k5qPgfM/725-D4685-A361-4-A36-BE98-14-D3-B2-D3-A369-4-5005-c.jpg';
+    const drawerCloseIcon = 'https://i.ibb.co/858qKcX/AB15-B4-AB-1-EE9-4597-800-B-965-F7-D1460-D7-4-5005-c.jpg';
     const DrawerContainer = styled.div`
         position: fixed;
         display: flex;
@@ -17,11 +19,14 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         position: fixed;
         display: flex;
         flex-flow: row;
-        width: 10em;
+        width: 2em;
         height: 100vh;
         top: 0;
         right: ${hide ? '34rem' : '0'};
-        background: #000;
+        background-image: url(${hide ? drawerOpenIcon : drawerCloseIcon});
+        background-repeat: no-repeat;
+        
+        background-position: center;
     `;
     const DrawerContents = styled.div`
         width: 90em;

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -71,6 +71,8 @@ const Drawer = ({ state, hide, onToggleClick }) => {
                         <br/>
                         <h2><b>[LH 청년매입] {state.name}</b></h2>
                         <br/>
+                        <p>- 주소 : {state.address.split("(")[0]}</p>
+                        <br/>
                         <p>- 승강기 유무 : {state.elevator==="Y"? "있음" : state.elevator==="N"? "없음": "알수없음"}</p>
                         <br/>
                         <p>- 임대조건 (2,3순위 청년 기준, 보증금 최대전환 시)</p>

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -1,24 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
-const Drawer = ({ state }) => {
+const Drawer = ({ state, hide, onToggleClick }) => {
     const theme = useTheme();
-    const [hide, setHide] = useState(false);
-    useEffect(() => {
-        setHide(true);
-    }, [state]);
 
     const DrawerContainer = styled.div`
         position: fixed;
         display: flex;
         flex-flow: row;
         width: 34rem;
-        height: 99vh;
+        height: 100vh;
         top: 0;
         right: ${hide ? '0' : '-30rem'};
     `;
     const DrawerEventBox = styled.div`
+        position: fixed;
+        display: flex;
+        flex-flow: row;
         width: 10em;
+        height: 100vh;
+        top: 0;
+        right: ${hide ? '34rem' : '0'};
         background: #000;
     `;
     const DrawerContents = styled.div`
@@ -33,32 +35,35 @@ const Drawer = ({ state }) => {
         border: 1px grey solid;
     `;
     return (
-        <DrawerContainer>
-            <DrawerEventBox onClick={() => setHide((f) => !f)} />
-            <DrawerContents>
-                {state.name}
-                {state.sells &&
-                    state.sells.map((home) => (
-                        <>
-                            <ul>
-                                <li>주택정보: {home.classes} </li>
-                                <li>보증금: {home.totalPrice}</li>
-                                <li>임대료: {home.monthPay}</li>
-                            </ul>
-                        </>
-                        
-                        // <ContentsBox>
-                        //     {Object.values(home).map((item) => (
-                        //         <>
-                        //             <p>{item}</p>
-                                    
-                        //         </>
-                        //         // <p>{x}</p>
-                        //     ))}
-                        // </ContentsBox>
-                    ))}
-            </DrawerContents>
-        </DrawerContainer>
+        <>
+            <DrawerEventBox onClick={onToggleClick} />
+            {hide && <DrawerContainer>
+                <DrawerContents>
+                    {state.name}
+                    {<p>임대조건(2,3순위 청년 기준, 보증금 최대전환 시)</p>}
+                    {state.sells &&
+                        state.sells.map((home) => (
+                            <>
+                                <ul>
+                                    <li>주택정보: {home.classes} </li>
+                                    <li>보증금: {home.totalPrice}</li>
+                                    <li>임대료: {home.monthPay}</li>
+                                </ul>
+                            </>
+                            
+                            // <ContentsBox>
+                            //     {Object.values(home).map((item) => (
+                            //         <>
+                            //             <p>{item}</p>
+                                        
+                            //         </>
+                            //         // <p>{x}</p>
+                            //     ))}
+                            // </ContentsBox>
+                        ))}
+                </DrawerContents>
+            </DrawerContainer>}
+        </>
     );
 };
 

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -29,7 +29,7 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         background-position: center;
     `;
     const DrawerContents = styled.div`
-        width: 100vw;
+        width: 24rem;
         height: 100vh;
         padding-left: 2rem;
         background: #ffffff;

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -10,7 +10,7 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         position: fixed;
         display: flex;
         flex-flow: row;
-        width: 34rem;
+        width: 24rem;
         height: 100vh;
         top: 0;
         right: ${hide ? '0' : '-30rem'};
@@ -22,16 +22,18 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         width: 2em;
         height: 100vh;
         top: 0;
-        right: ${hide ? '34rem' : '0'};
+        right: ${hide ? '24rem' : '0'};
         background-image: url(${hide ? drawerOpenIcon : drawerCloseIcon});
         background-repeat: no-repeat;
-        
         background-position: center;
     `;
     const DrawerContents = styled.div`
         width: 90em;
-        padding: 3em;
+        padding: 2em;
         background: #ffffff;
+        li {
+            padding: 0.3em;
+        }
     `;
     const ContentsBox = styled.div`
         margin: 1em;
@@ -44,27 +46,21 @@ const Drawer = ({ state, hide, onToggleClick }) => {
             <DrawerEventBox onClick={onToggleClick} />
             {hide && <DrawerContainer>
                 <DrawerContents>
-                    {state.name}
-                    {<p>임대조건(2,3순위 청년 기준, 보증금 최대전환 시)</p>}
+                    {<h2><b>[LH 청년매입] {state.name}</b></h2>}
+                    {<br/>}
+                    {<p>- 임대조건 (2,3순위 청년 기준, 보증금 최대전환 시)</p>}
+                    {<br/>}
+                    {<br/>}
                     {state.sells &&
                         state.sells.map((home) => (
                             <>
                                 <ul>
-                                    <li>주택정보: {home.classes} </li>
-                                    <li>보증금: {home.totalPrice}</li>
-                                    <li>임대료: {home.monthPay}</li>
+                                    <li>* 주택정보: {home.classes} </li>
+                                    <li>* 보증금: {home.totalPrice}</li>
+                                    <li>* 임대료: {home.monthPay}</li>
                                 </ul>
+                                <br/>
                             </>
-                            
-                            // <ContentsBox>
-                            //     {Object.values(home).map((item) => (
-                            //         <>
-                            //             <p>{item}</p>
-                                        
-                            //         </>
-                            //         // <p>{x}</p>
-                            //     ))}
-                            // </ContentsBox>
                         ))}
                 </DrawerContents>
             </DrawerContainer>}

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -12,6 +12,7 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         flex-flow: row;
         width: 24rem;
         height: 100vh;
+        background: #ffffff;
         top: 0;
         right: ${hide ? '0' : '-30rem'};
     `;
@@ -19,7 +20,7 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         position: fixed;
         display: flex;
         flex-flow: row;
-        width: 2em;
+        width: 2rem;
         height: 100vh;
         top: 0;
         right: ${hide ? '24rem' : '0'};
@@ -30,11 +31,13 @@ const Drawer = ({ state, hide, onToggleClick }) => {
     const DrawerContents = styled.div`
         width: 100vw;
         height: 100vh;
-        padding-top: 2em;
-        padding-left: 2em;
+        padding-left: 2rem;
         background: #ffffff;
         li {
             padding: 0.3em;
+        }
+        p#eof{
+            text-align: center;
         }
     `;
     const ContentsBox = styled.div`
@@ -65,12 +68,12 @@ const Drawer = ({ state, hide, onToggleClick }) => {
                 <DrawerContents>
                     <InfoWindowScroll>
                         <>
+                        <br/>
                         <h2><b>[LH 청년매입] {state.name}</b></h2>
                         <br/>
                         <p>- 승강기 유무 : {state.elevator==="Y"? "있음" : state.elevator==="N"? "없음": "알수없음"}</p>
                         <br/>
                         <p>- 임대조건 (2,3순위 청년 기준, 보증금 최대전환 시)</p>
-                        <br/>
                         <br/>
                         <br/>
                         {state.sells &&
@@ -87,6 +90,7 @@ const Drawer = ({ state, hide, onToggleClick }) => {
                             ))
                         }
                         </>
+                        <p id="eof">이하 빈칸</p>
                     </InfoWindowScroll>
                 </DrawerContents>
             </DrawerContainer>}

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -28,8 +28,10 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         background-position: center;
     `;
     const DrawerContents = styled.div`
-        width: 90em;
-        padding: 2em;
+        width: 100vw;
+        height: 100vh;
+        padding-top: 2em;
+        padding-left: 2em;
         background: #ffffff;
         li {
             padding: 0.3em;
@@ -41,27 +43,47 @@ const Drawer = ({ state, hide, onToggleClick }) => {
         height: 10em;
         border: 1px grey solid;
     `;
+
+    const InfoWindowScroll = styled.div`
+        overflow: auto;
+        height: 100vh;
+        &::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+            border-radius: 6px;
+            background: rgba(255, 255, 255, 0.4);
+        }
+        &::-webkit-scrollbar-thumb {
+            background: rgba(0, 0, 0, 0.3);
+            border-radius: 6px;
+        }
+    `;
     return (
         <>
             <DrawerEventBox onClick={onToggleClick} />
             {hide && <DrawerContainer>
                 <DrawerContents>
-                    {<h2><b>[LH 청년매입] {state.name}</b></h2>}
-                    {<br/>}
-                    {<p>- 임대조건 (2,3순위 청년 기준, 보증금 최대전환 시)</p>}
-                    {<br/>}
-                    {<br/>}
-                    {state.sells &&
-                        state.sells.map((home) => (
-                            <>
-                                <ul>
-                                    <li>* 주택정보: {home.classes} </li>
-                                    <li>* 보증금: {home.totalPrice}</li>
-                                    <li>* 임대료: {home.monthPay}</li>
-                                </ul>
-                                <br/>
-                            </>
-                        ))}
+                    <InfoWindowScroll>
+                        <>
+                        <h2><b>[LH 청년매입] {state.name}</b></h2>
+                        <br/>
+                        <p>- 임대조건 (2,3순위 청년 기준, 보증금 최대전환 시)</p>
+                        <br/>
+                        <br/>
+                        {state.sells &&
+                            state.sells.map((home) => (
+                                <>
+                                    <ul>
+                                        <li>* 주택정보: {home.classes} </li>
+                                        <li>* 보증금: {home.totalPrice}</li>
+                                        <li>* 임대료: {home.monthPay}</li>
+                                    </ul>
+                                    <br/>
+                                </>
+                            ))
+                        }
+                        </>
+                    </InfoWindowScroll>
                 </DrawerContents>
             </DrawerContainer>}
         </>

--- a/src/container/Home/Drawer/index.js
+++ b/src/container/Home/Drawer/index.js
@@ -67,7 +67,10 @@ const Drawer = ({ state, hide, onToggleClick }) => {
                         <>
                         <h2><b>[LH 청년매입] {state.name}</b></h2>
                         <br/>
+                        <p>- 승강기 유무 : {state.elevator==="Y"? "있음" : state.elevator==="N"? "없음": "알수없음"}</p>
+                        <br/>
                         <p>- 임대조건 (2,3순위 청년 기준, 보증금 최대전환 시)</p>
+                        <br/>
                         <br/>
                         <br/>
                         {state.sells &&
@@ -75,8 +78,9 @@ const Drawer = ({ state, hide, onToggleClick }) => {
                                 <>
                                     <ul>
                                         <li>* 주택정보: {home.classes} </li>
-                                        <li>* 보증금: {home.totalPrice}</li>
-                                        <li>* 임대료: {home.monthPay}</li>
+                                        <li>* 방수: {home.roomCount} </li>
+                                        <li>* 보증금: {home.totalPrice} </li>
+                                        <li>* 임대료: {home.monthPay} </li>
                                     </ul>
                                     <br/>
                                 </>

--- a/src/container/Home/HomeMarker/index.js
+++ b/src/container/Home/HomeMarker/index.js
@@ -29,7 +29,7 @@ import Marker from '../../../components/NaverMap/Marker';
   }
 */
 
-function HomeMarker({ data, callback }) {
+function HomeMarker({ data, onMarkerClick }) {
     const theme = useTheme();
 
     const SummaryInfoContainer = styled.div`
@@ -55,7 +55,7 @@ function HomeMarker({ data, callback }) {
                 lat: data.lat,
                 lng: data.lng,
             }}
-            onClick={() => callback(data)}
+            onClick={()=>onMarkerClick(data)}
         >
             <SummaryInfoContainer>
                 <SummaryInfoIcon />

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -6,7 +6,7 @@ function MyApp({ Component, pageProps }) {
     return (
         <ThemeProvider theme={theme}>
             <GlobalStyle />
-            <Component {...pageProps} />;
+            <Component {...pageProps} />
         </ThemeProvider>
     );
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -70,10 +70,17 @@ const preprocessingLH = (datas) => {
 
 export default function Home({ spreadSheetData }) {
     const [homes, setHomes] = useState([]);
+    const [hide, setHide] = useState(false);
     const HomeBucket = useMemo(() => {
         return(Object.values(preprocessingLH(spreadSheetData)));
     }, []);
-
+    const handleDrawerHide = () => setHide(true)
+    const handleDrawerEvent = () => setHide((f) => !f)
+    const handleDataSet = (data) => setHomes(data)
+    const handlers = (data) => {
+        handleDataSet(data)
+        handleDrawerHide()
+    }
     return (
         <div>
             <Head>
@@ -88,13 +95,13 @@ export default function Home({ spreadSheetData }) {
             <main>
                 <NaverMap>
                     <Header />
-                    <Drawer state={homes} />
+                    <Drawer state={homes} hide={hide} onToggleClick={handleDrawerEvent}/>
                     {HomeBucket.map((data) => {
                         return (
                             <HomeMarker
                                 key={`key_${data.lat}${data.lng}`}
                                 data={data}
-                                callback={(data) => setHomes(data)}
+                                onMarkerClick={handlers}
                             />
                         );
                     })}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,7 +39,8 @@ const preprocessingLH = (datas) => {
                     "호 " +
                     Number(homeObject['전용면적']) +
                     "㎡",
-                roomCount:homeObject['방수'],
+                roomCount: homeObject['방수'] + "개",
+                elevator: homeObject['승강기'],
                 totalPrice: addCommas(convertToNumber(homeObject['임대보증금(원)']) / 10000) + "만원",
                 monthPay: homeObject['월임대료(원)'].trim() + "원",
             }
@@ -55,13 +56,14 @@ const preprocessingLH = (datas) => {
     });
   
     homesList.forEach(
-      ({ lng, lat, keyCoords, address, classes, monthPay, name, totalPrice, roomCount }) => {
+      ({ lng, lat, keyCoords, address, classes, monthPay, name, totalPrice, roomCount, elevator }) => {
         const Obj = homesReuslt.filter((e) => e.keyCoords === keyCoords)[0];
         Obj.gov = "LH 청년매입";
         Obj.name = name;
         Obj.address = address;
-        Obj.lat = lat
-        Obj.lng = lng
+        Obj.lat = lat;
+        Obj.lng = lng;
+        Obj.elevator = elevator;
         Obj.sells.push({ classes, roomCount, totalPrice, monthPay });
       }
     );


### PR DESCRIPTION
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/20448972/192593456-a64bf487-7484-499a-83d5-6eb6cc78d251.png">

변경 내용
- Drawer 초기 접속시 접혀있고 마커를 클릭하면 펼쳐지도록 -> 가장 많은 변경입니다. useEffect로 사용하던걸 온클릭 핸들로 처리하였습니다. state 변경 시 마다 펼쳐지도록 되어 있는데 접속 초기에도 hide가 true가 되어 drawer 펼쳐지기 때문입니다. 제 기준에서는 hide 이름 보다는 spread나 open이 덜 혼란스럽겠습니다. 변수이름은 수정하지 않았습니다.
- Drawer toggle 버튼 ui
- Drawer에 scroll 추가
- ; 이슈 -> ㅋㅋㅋㅋㅋㅋㅋ
- 표시되는 정보 수정

늦은 감이 있지만 드디어 사용자에게 배포를 할까합니다. 검색기능은 지금 꼭 필요한건 아니라 내일 오전까지 어렵다면 오후에 지우고 배포하겠습니다. @ParkAward 
마지막으로 주소가 맞는지, 기타 치명적인 버그는 없는지 시간 나면 확인 부탁드립니다! 테스팅 페이지 입니다. https://public-home-i2cnwhgxn-lifeisalone.vercel.app/
vercel은 push하면 임시테스팅 페이지가 만들어지니까 매우 좋네요 ㅎㅎ